### PR TITLE
Batches not always getting executed

### DIFF
--- a/src/WindowsAzure/Table/RequestExecutor/TableRequestParallelExecutor.cs
+++ b/src/WindowsAzure/Table/RequestExecutor/TableRequestParallelExecutor.cs
@@ -59,7 +59,8 @@ namespace WindowsAzure.Table.RequestExecutor
             IEnumerable<ITableEntity> tableEntities = entities.Select(p => _entityConverter.GetEntity(p));
             IEnumerable<TableBatchOperation> batches = _partitioner.GetBatches(tableEntities, operation);
 
-            return batches.AsParallel().SelectMany(GetEntities);
+            // Force evaluation of the execution by calling ToArray()
+            return batches.AsParallel().SelectMany(GetEntities).ToArray();
         }
 
         /// <summary>

--- a/src/WindowsAzure/Table/RequestExecutor/TableRequestSequentialExecutor.cs
+++ b/src/WindowsAzure/Table/RequestExecutor/TableRequestSequentialExecutor.cs
@@ -59,9 +59,9 @@ namespace WindowsAzure.Table.RequestExecutor
             IEnumerable<ITableEntity> tableEntities = entities.Select(p => _entityConverter.GetEntity(p));
             IEnumerable<TableBatchOperation> batches = _partitioner.GetBatches(tableEntities, operation);
 
-            return from batch in batches
-                   from result in _cloudTable.ExecuteBatch(batch)
-                   select _entityConverter.GetEntity((DynamicTableEntity) result.Result);
+            // Force evaluation of the execution by calling ToArray()
+            var results = batches.SelectMany(t => _cloudTable.ExecuteBatch(t)).ToArray();
+            return results.Select(t => _entityConverter.GetEntity((DynamicTableEntity) t.Result));
         }
 
         /// <summary>

--- a/test/WindowsAzure.Tests/Table/RequestExecutor/ParallelExecutorTests.cs
+++ b/test/WindowsAzure.Tests/Table/RequestExecutor/ParallelExecutorTests.cs
@@ -105,6 +105,24 @@ namespace WindowsAzure.Tests.Table.RequestExecutor
         }
 
         [Fact]
+        public void ExecuteBatchesEvenWhenNotEvaluated()
+        {
+            // Arrange
+            Mock<ICloudTable> cloudTableMock = MocksFactory.GetCloudTableMock();
+            Mock<ITableEntityConverter<Country>> entityConverterMock = MocksFactory.GetTableEntityConverterMock<Country>();
+            Mock<ITableBatchPartitioner> batchPartitionerMock = MocksFactory.GetTableBatchPartitionerMock();
+            var executor = new TableRequestParallelExecutor<Country>(cloudTableMock.Object, entityConverterMock.Object, batchPartitionerMock.Object);
+            var entities = ObjectsFactory.GetCountries();
+
+            // Act
+            // We don't evaluate the call as we're not interested in the resulting entities. This should still execute the operations.
+            executor.ExecuteBatches(entities, TableOperation.Insert);
+
+            // Assert
+            cloudTableMock.Verify(t => t.ExecuteBatch(It.IsAny<TableBatchOperation>()));
+        }
+
+        [Fact]
         public Task ExecuteBatchesAsyncWithNullEntities()
         {
             // Arrange

--- a/test/WindowsAzure.Tests/Table/RequestExecutor/SequentialExecutorTests.cs
+++ b/test/WindowsAzure.Tests/Table/RequestExecutor/SequentialExecutorTests.cs
@@ -105,6 +105,24 @@ namespace WindowsAzure.Tests.Table.RequestExecutor
         }
 
         [Fact]
+        public void ExecuteBatchesEvenWhenNotEvaluated()
+        {
+            // Arrange
+            Mock<ICloudTable> cloudTableMock = MocksFactory.GetCloudTableMock();
+            Mock<ITableEntityConverter<Country>> entityConverterMock = MocksFactory.GetTableEntityConverterMock<Country>();
+            Mock<ITableBatchPartitioner> batchPartitionerMock = MocksFactory.GetTableBatchPartitionerMock();
+            var executor = new TableRequestSequentialExecutor<Country>(cloudTableMock.Object, entityConverterMock.Object, batchPartitionerMock.Object);
+            var entities = ObjectsFactory.GetCountries();
+
+            // Act
+            // We don't evaluate the call as we're not interested in the resulting entities. This should still execute the operations.
+            executor.ExecuteBatches(entities, TableOperation.Insert);
+
+            // Assert
+            cloudTableMock.Verify(t => t.ExecuteBatch(It.IsAny<TableBatchOperation>()));
+        }
+
+        [Fact]
         public Task ExecuteBatchesAsyncWithNullEntities()
         {
             // Arrange


### PR DESCRIPTION
Fix issue that results in batches not being executed if the caller doesn't evaluate the result of a table operation. Fixes #28