### PR TITLE
Ignoring a property is not properly respected

### DIFF
--- a/test/WindowsAzure.Tests/Samples/EntityWithInvalidPropertyType.cs
+++ b/test/WindowsAzure.Tests/Samples/EntityWithInvalidPropertyType.cs
@@ -1,0 +1,12 @@
+﻿namespace WindowsAzure.Tests.Samples
+{
+    public class EntityWithInvalidPropertyType
+    {
+        public string PKey { get; set; }
+        public string RKey { get; set; }
+
+        // Non-supported property type
+        public Country Country { get; set; }
+    }
+
+}

--- a/test/WindowsAzure.Tests/Table/EntityConverters/TypeData/EntityTypeMapTests.cs
+++ b/test/WindowsAzure.Tests/Table/EntityConverters/TypeData/EntityTypeMapTests.cs
@@ -108,5 +108,20 @@ namespace WindowsAzure.Tests.Table.EntityConverters.TypeData
             Assert.Equal(1, map.NameChanges.Count);
             Assert.Equal("PartitionKey", map.NameChanges["Country"]);
         }
+
+        [Fact]
+        public void GetEntityTypeData_IgnoreProperty_EvenWhenUnsupportedType()
+        {
+            // Arrange & Act
+            var map = new EntityTypeMap<EntityWithInvalidPropertyType>(e =>
+                e.PartitionKey(p => p.PKey)
+                .RowKey(p => p.RKey)
+                .Ignore(p => p.Country));
+
+            // Assert
+            Assert.NotNull(map.NameChanges);
+            Assert.DoesNotContain(map.NameChanges, t => t.Key == "Country");
+            Assert.Equal(2, map.NameChanges.Count);
+        }
     }
 }

--- a/test/WindowsAzure.Tests/WindowsAzure.Tests.csproj
+++ b/test/WindowsAzure.Tests/WindowsAzure.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Samples\Countries.cs" />
     <Compile Include="Samples\EntityWithContructor.cs" />
     <Compile Include="Samples\EntityWithFields.cs" />
+    <Compile Include="Samples\EntityWithInvalidPropertyType.cs" />
     <Compile Include="Samples\EntityWithMultipleAttributes.cs" />
     <Compile Include="Samples\EntityWithoutCompositeKey.cs" />
     <Compile Include="Samples\EntityWithProperties.cs" />


### PR DESCRIPTION
If your model has an unsupported property type on it (e.g. an enum or another class) then you should be able to mark this property as being ignored (it can then still be used by your application). However, due to the way the EntityTypeMap auto-maps its properties on construction it doesn't know that the property is to be ignored (this is only found out after construction).

I'm guessing this is quite a sizable change but am thinking the best way would be to separate evaluation an building of the entity mapping from that of the mapping config itself, i.e the mapping config just becomes dumb and something else evaluates this.