### PR TITLE
Fixes dtretyakov/WindowsAzure#35

### DIFF
--- a/test/WindowsAzure.Tests/Extensions/PredicateExtensions.cs
+++ b/test/WindowsAzure.Tests/Extensions/PredicateExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace WindowsAzure.Tests.Extensions
+{
+    /// <summary>
+    /// https://www.simple-talk.com/dotnet/.net-framework/giving-clarity-to-linq-queries-by-extending-expressions/
+    /// </summary>
+    public static class PredicateExtensions
+    {
+        /// <summary>
+        /// Begin an expression chain
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">Default return value if the chanin is ended early</param>
+        /// <returns>A lambda expression stub</returns>
+        public static Expression<Func<T, bool>> Begin<T>(bool value = false)
+        {
+            if (value)
+                return parameter => true; //value cannot be used in place of true/false
+
+            return parameter => false;
+        }
+
+        public static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right)
+        {
+            return CombineLambdas(left, right, ExpressionType.AndAlso);
+        }
+
+        public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right)
+        {
+            return CombineLambdas(left, right, ExpressionType.OrElse);
+        }
+
+        #region private
+
+        private static Expression<Func<T, bool>> CombineLambdas<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right, ExpressionType expressionType)
+        {
+            //Remove expressions created with Begin<T>()
+            if (IsExpressionBodyConstant(left))
+                return (right);
+
+            var p = left.Parameters[0];
+
+            var visitor = new SubstituteParameterVisitor();
+            visitor.Sub[right.Parameters[0]] = p;
+
+            Expression body = Expression.MakeBinary(expressionType, left.Body, visitor.Visit(right.Body));
+            return Expression.Lambda<Func<T, bool>>(body, p);
+        }
+
+        private static bool IsExpressionBodyConstant<T>(Expression<Func<T, bool>> left)
+        {
+            return left.Body.NodeType == ExpressionType.Constant;
+        }
+
+        internal class SubstituteParameterVisitor : ExpressionVisitor
+        {
+            public Dictionary<Expression, Expression> Sub = new Dictionary<Expression, Expression>();
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                Expression newValue;
+                return Sub.TryGetValue(node, out newValue) ? newValue : node;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/WindowsAzure.Tests/Table/Queryable/Integration/ExpressionTests.cs
+++ b/test/WindowsAzure.Tests/Table/Queryable/Integration/ExpressionTests.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using WindowsAzure.Table;
+using WindowsAzure.Tests.Attributes;
+using WindowsAzure.Tests.Extensions;
+using WindowsAzure.Tests.Samples;
+using Xunit;
+
+namespace WindowsAzure.Tests.Table.Queryable.Integration
+{
+    public sealed class ExpressionTests : CountryTableSetBase
+    {
+        private const string Germany = "Germany";
+        private const string Spain = "Spain";
+        private const string Finland = "Finland";
+        private const string France = "France";
+
+        public ExpressionTests()
+        {
+            TableSet<Country> tableSet = GetTableSet();
+            tableSet.Add(
+                new Country
+                    {
+                        Area = 357021,
+                        Continent = "Europe",
+                        TopSecretKey = new byte[] {0xaa, 0xbb, 0xcc},
+                        Formed = new DateTime(1871, 1, 18),
+                        Id = Guid.NewGuid(),
+                        IsExists = true,
+                        Name = Germany,
+                        Population = 81799600,
+                        PresidentsCount = 11
+                    });
+            tableSet.Add(
+                new Country
+                    {
+                        Area = 505992,
+                        Continent = "Europe",
+                        TopSecretKey = new byte[] {0xaa, 0xbb, 0xcc},
+                        Formed = new DateTime(1812, 1, 1),
+                        Id = Guid.NewGuid(),
+                        IsExists = false,
+                        Name = Spain,
+                        Population = 47190493,
+                        PresidentsCount = 8
+                    });
+            tableSet.Add(
+                new Country
+                    {
+                        Area = 674843,
+                        Continent = "Europe",
+                        TopSecretKey = new byte[] {0xaa, 0xbb, 0xcc},
+                        Formed = new DateTime(1792, 1, 1),
+                        Id = Guid.NewGuid(),
+                        IsExists = true,
+                        Name = France,
+                        Population = 65350000,
+                        PresidentsCount = 24
+                    });
+            tableSet.Add(
+                new Country
+                    {
+                        Area = 338424,
+                        Continent = "Europe",
+                        TopSecretKey = new byte[] {0xaa, 0xbb, 0xcc},
+                        Formed = new DateTime(1809, 3, 29),
+                        Id = Guid.NewGuid(),
+                        IsExists = true,
+                        Name = Finland,
+                        Population = 5421827,
+                        PresidentsCount = 12
+                    });
+        }
+
+        [IntegrationFact]
+        public void QueryWithContains()
+        {
+            // Arrange
+            var names = new List<string>
+                {
+                    Germany,
+                    Finland
+                };
+           TableSet<Country> tableSet = GetTableSet();
+
+           Expression<Func<Country, bool>> hasName = x => names.Contains(x.Name);
+            // Act
+           List<Country> result = tableSet.Where(hasName).ToList();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            List<string> resultNames = result.Select(p => p.Name).ToList();
+            Assert.Contains(Germany, resultNames);
+            Assert.Contains(Finland, resultNames);
+        }
+
+        [IntegrationFact]
+        public void QueryWithContainsAndExists()
+        {
+            // Arrange
+            var names = new List<string>
+                {
+                    Germany,
+                    Finland
+                };
+            TableSet<Country> tableSet = GetTableSet();
+
+            Expression<Func<Country, bool>> hasName = x => names.Contains(x.Name);
+            Expression<Func<Country, bool>> exists = x => x.IsExists;
+
+            var filter = hasName.And(exists);
+
+            // Act
+            List<Country> result = tableSet.Where(filter).ToList();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            List<string> resultNames = result.Select(p => p.Name).ToList();
+            Assert.Contains(Germany, resultNames);
+            Assert.Contains(Finland, resultNames);
+        }
+
+        [IntegrationFact]
+        public void QueryWithContainsAndComplexFunction()
+        {
+            // Arrange
+            var names = new List<string>
+                {
+                    Germany,
+                    Finland
+                };
+            TableSet<Country> tableSet = GetTableSet();
+
+            Expression<Func<Country, bool>> hasName = x => names.Contains(x.Name);
+            Expression<Func<Country, bool>> exists = x => x.IsExists && x.Population > 1000000;
+
+            var filter = hasName.And(exists);
+
+            // Act
+            List<Country> result = tableSet.Where(filter).ToList();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            List<string> resultNames = result.Select(p => p.Name).ToList();
+            Assert.Contains(Germany, resultNames);
+            Assert.Contains(Finland, resultNames);
+        }
+    }
+}

--- a/test/WindowsAzure.Tests/WindowsAzure.Tests.csproj
+++ b/test/WindowsAzure.Tests/WindowsAzure.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Common\MocksFactory.cs" />
     <Compile Include="Common\ObjectsFactory.cs" />
     <Compile Include="Common\TestBase.cs" />
+    <Compile Include="Extensions\PredicateExtensions.cs" />
     <Compile Include="Samples\Address.cs" />
     <Compile Include="Samples\Countries.cs" />
     <Compile Include="Samples\EntityWithContructor.cs" />
@@ -127,6 +128,7 @@
     <Compile Include="Table\EntityConverters\Properties\RowKeyPropertyTests.cs" />
     <Compile Include="Table\EntityConverters\Properties\PartitionKeyPropertyTests.cs" />
     <Compile Include="Table\EntityConverters\TypeData\EntityTypeMapTests.cs" />
+    <Compile Include="Table\Queryable\Integration\ExpressionTests.cs" />
     <Compile Include="Table\Queryable\Integration\ContainsTests.cs" />
     <Compile Include="Table\Queryable\Integration\SingleTests.cs" />
     <Compile Include="Table\Queryable\Integration\SingleOrDefaultTests.cs" />


### PR DESCRIPTION
The TrimString method was removing parenthesis from the start/end of the _filter even when they were required.  

Credit to [pkuderov for code on StackOverflow](http://stackoverflow.com/a/18884516).
I made slight modifications to prevent index out of bound exceptions, and to trim whitespace.

