### PR TITLE
set result of table query to return object (.NET Core configuration)

### DIFF
--- a/WindowsAzure/Table/Extensions/CloudTableExtensions.cs
+++ b/WindowsAzure/Table/Extensions/CloudTableExtensions.cs
@@ -477,6 +477,7 @@ namespace WindowsAzure.Table.Extensions
             do
             {
                 var result = await cloudTable.ExecuteQuerySegmentedAsync(tableQuery, token, null, null, cancellationToken);
+                tableEntities.AddRange(result.Results);
 
                 // Checks whether TakeCount entities has been received
                 if (tableQuery.TakeCount.HasValue && tableEntities.Count >= tableQuery.TakeCount.Value)


### PR DESCRIPTION
In using this library with .NET Core we saw that Table Queries were not returning results but we saw the request was being issued successfully to Azure Table Storage.

We found that the result was not being assigned to the list of objects to return, hence the update below.